### PR TITLE
Develop

### DIFF
--- a/doc/extensions/binary.md
+++ b/doc/extensions/binary.md
@@ -50,12 +50,12 @@ binary_t binary_subbin(const binary_t bin, int start, int len);
 *   Returned value should be freed by `binary_free()`.
 
 ```c
-void binary_free(binary_t bin);
+void binary_free(binary_t *bin);
 ```
 *   `binary_t` object will be freed.
 *   Do not use it after freed.
 
 ```c
-void binary_clear(binary_t bin);
+void binary_clear(binary_t *bin);
 ```
 *   Make the `binary_t` object empty.

--- a/doc/extensions/string.md
+++ b/doc/extensions/string.md
@@ -50,12 +50,12 @@ string_t string_substr(const string_t str, int start, int len);
 *   Returned value should be freed by `string_free()`.
 
 ```c
-void string_free(string_t str);
+void string_free(string_t *str);
 ```
 *   `string_t` object will be freed.
 *   Do not use it after freed.
 
 ```c
-void string_clear(string_t str);
+void string_clear(string_t *str);
 ```
 *   Make the `string_t` object empty.

--- a/include/kcc.h
+++ b/include/kcc.h
@@ -53,4 +53,14 @@ extern uint64_t *kcc_argv;
 #endif
 #endif
 
+#if defined(KCC_WINDOWS)
+#if defined(KCC_WINDOWS_DEBUG)
+#define DEBUG 1
+#define _DEBUG 1
+#define _CRTDBG_MAP_ALLOC
+#include <stdlib.h>
+#include <crtdbg.h>
+#endif
+#endif
+
 #endif

--- a/kccrt/include/kcc/ext.h
+++ b/kccrt/include/kcc/ext.h
@@ -24,8 +24,8 @@ extern void string_append(string_t* lhs, const string_t rhs);
 extern void string_append_cstr(string_t* lhs, const char *rhs);
 extern string_t string_substr(const string_t str, int start, int len);
 
-#define string_free(str)    free((str).cstr)
-#define string_clear(str)   (((str).cstr ? ((str).cstr[0] = 0) : 0), (str).len = 0)
+#define string_free(str)    free((str)->cstr)
+#define string_clear(str)   (((str)->cstr ? ((str)->cstr[0] = 0) : 0), (str)->len = 0)
 
 #ifndef KCC_NO_IMPORT
 #if defined(__KCC_JIT__) || defined(__KCC__)
@@ -49,8 +49,8 @@ extern void binary_append(binary_t* lhs, const binary_t rhs);
 extern void binary_append_bytes(binary_t* lhs, const uint8_t *rhs, int len);
 extern binary_t binary_subbin(const binary_t ary, int start, int len);
 
-#define binary_free(bin)    free((bin).buf)
-#define binary_clear(bin)   ((bin).len = 0)
+#define binary_free(bin)    free((bin)->buf)
+#define binary_clear(bin)   ((bin)->len = 0)
 
 #ifndef KCC_NO_IMPORT
 #if defined(__KCC_JIT__) || defined(__KCC__)

--- a/kccrt/include/kcc/ext.h
+++ b/kccrt/include/kcc/ext.h
@@ -25,7 +25,7 @@ extern void string_append_cstr(string_t* lhs, const char *rhs);
 extern string_t string_substr(const string_t str, int start, int len);
 
 #define string_free(str)    free((str).cstr)
-#define string_clear(str)   ((str).len = 0)
+#define string_clear(str)   (((str).cstr ? ((str).cstr[0] = 0) : 0), (str).len = 0)
 
 #ifndef KCC_NO_IMPORT
 #if defined(__KCC_JIT__) || defined(__KCC__)

--- a/kccrt/libsrc/_builtin.c
+++ b/kccrt/libsrc/_builtin.c
@@ -3,11 +3,20 @@
 
 typedef void (*kcc_atexit_func_t)(void);
 #define KCC_MAX_ATEXIT_FUNC_COUNT (128)
-static kcc_atexit_func_t kcc_atexit_func[KCC_MAX_ATEXIT_FUNC_COUNT] = {0};
+static kcc_atexit_func_t *kcc_atexit_func = 0;
 static int kcc_atexit_func_count = 0;
+
+int puts(const char *s);
 
 int atexit(kcc_atexit_func_t func)
 {
+    if (!kcc_atexit_func) {
+        kcc_atexit_func = __kcc_builtin_calloc(KCC_MAX_ATEXIT_FUNC_COUNT, sizeof(kcc_atexit_func_t));
+        if (!kcc_atexit_func) {
+            puts("memory allocation error on atexit.");
+            return 1;
+        }
+    }
     if (kcc_atexit_func_count < KCC_MAX_ATEXIT_FUNC_COUNT) {
         kcc_atexit_func[kcc_atexit_func_count++] = func;
         return 0;
@@ -17,10 +26,14 @@ int atexit(kcc_atexit_func_t func)
 
 void __kcc_call_atexit_funcs(void)
 {
-    for (int i = kcc_atexit_func_count - 1; i >= 0; --i) {
-        if (kcc_atexit_func[i]) {
-            (*kcc_atexit_func[i])();
+    if (kcc_atexit_func) {
+        for (int i = kcc_atexit_func_count - 1; i >= 0; --i) {
+            if (kcc_atexit_func[i]) {
+                (*kcc_atexit_func[i])();
+            }
         }
+        __kcc_builtin_free(kcc_atexit_func);
+        kcc_atexit_func = 0;
     }
 }
 

--- a/kccrt/libsrc/kcc/ext_binary.c
+++ b/kccrt/libsrc/kcc/ext_binary.c
@@ -35,7 +35,7 @@ void binary_append(binary_t* lhs, const binary_t rhs)
         uint8_t *buf = (uint8_t *)calloc(cap, sizeof(uint8_t));
         memcpy(buf, lhs->buf, lhs->len);
         memcpy(buf + lhs->len, rhs.buf, rhs.len);
-        binary_free(*lhs);
+        binary_free(lhs);
         lhs->len = len;
         lhs->cap = cap;
         lhs->buf = buf;
@@ -56,7 +56,7 @@ void binary_append_bytes(binary_t* lhs, const uint8_t *rhs, int rlen)
         uint8_t *buf = (uint8_t *)calloc(cap, sizeof(uint8_t));
         memcpy(buf, lhs->buf, lhs->len);
         memcpy(buf + lhs->len, rhs, len);
-        binary_free(*lhs);
+        binary_free(lhs);
         lhs->len = len;
         lhs->cap = cap;
         lhs->buf = buf;

--- a/kccrt/libsrc/kcc/ext_binary.c
+++ b/kccrt/libsrc/kcc/ext_binary.c
@@ -4,41 +4,21 @@
 
 binary_t binary_init(const uint8_t *src, int len)
 {
+    unsigned int cap = ((unsigned int)(len / KCC_CAPACITY_UNIT) + 1) * KCC_CAPACITY_UNIT;
+    uint8_t *buf = (uint8_t *)calloc(cap, sizeof(uint8_t));
     if (len > 0) {
-        unsigned int cap = ((unsigned int)(len / KCC_CAPACITY_UNIT) + 1) * KCC_CAPACITY_UNIT;
-        uint8_t *buf = (uint8_t *)calloc(cap, sizeof(uint8_t));
         memcpy(buf, src, len);
-        return (binary_t) {
-            .len = len,
-            .cap = cap,
-            .buf = buf,
-        };
     }
     return (binary_t) {
-        .len = 0,
-        .cap = 0,
-        .buf = NULL,
+        .len = len,
+        .cap = cap,
+        .buf = buf,
     };
 }
 
 binary_t binary_copy(const binary_t rhs)
 {
-    if (rhs.len > 0) {
-        // resizes a capacity.
-        unsigned int cap = ((unsigned int)(rhs.len / KCC_CAPACITY_UNIT) + 1) * KCC_CAPACITY_UNIT;
-        uint8_t *buf = (uint8_t *)calloc(cap, sizeof(uint8_t));
-        memcpy(buf, rhs.buf, rhs.len);
-        return (binary_t) {
-            .len = rhs.len,
-            .cap = cap,
-            .buf = buf,
-        };
-    }
-    return (binary_t) {
-        .len = 0,
-        .cap = 0,
-        .buf = NULL,
-    };
+    return binary_init(rhs.buf, rhs.len);
 }
 
 void binary_append(binary_t* lhs, const binary_t rhs)

--- a/kccrt/libsrc/kcc/ext_string.c
+++ b/kccrt/libsrc/kcc/ext_string.c
@@ -36,7 +36,7 @@ void string_append(string_t* lhs, const string_t rhs)
         char *buf = (char *)calloc(cap, sizeof(char));
         strcpy(buf, lhs->cstr);
         strcat(buf, rhs.cstr);
-        string_free(*lhs);
+        string_free(lhs);
         lhs->len = len;
         lhs->cap = cap;
         lhs->cstr = buf;
@@ -58,7 +58,7 @@ void string_append_cstr(string_t* lhs, const char *rhs)
         char *buf = (char *)calloc(cap, sizeof(char));
         strcpy(buf, lhs->cstr);
         strcat(buf, rhs);
-        string_free(*lhs);
+        string_free(lhs);
         lhs->len = len;
         lhs->cap = cap;
         lhs->cstr = buf;

--- a/kccrt/libsrc/kcc/ext_string.c
+++ b/kccrt/libsrc/kcc/ext_string.c
@@ -4,41 +4,22 @@
 string_t string_init(const char *cstr)
 {
     unsigned int len = cstr ? strlen(cstr) : 0;
+    unsigned int cap = ((unsigned int)(len / KCC_CAPACITY_UNIT) + 1) * KCC_CAPACITY_UNIT;
+    char *buf = (char *)calloc(cap, sizeof(char));
     if (len > 0) {
-        unsigned int cap = ((unsigned int)(len / KCC_CAPACITY_UNIT) + 1) * KCC_CAPACITY_UNIT;
-        char *buf = (char *)calloc(cap, sizeof(char));
         strcpy(buf, cstr);
-        return (string_t) {
-            .len = len,
-            .cap = cap,
-            .cstr = buf,
-        };
     }
     return (string_t) {
-        .len = 0,
-        .cap = 0,
-        .cstr = NULL,
+        .len = len,
+        .cap = cap,
+        .cstr = buf,
     };
 }
 
 string_t string_copy(const string_t rhs)
 {
-    if (rhs.len > 0) {
-        // resizes a capacity.
-        unsigned int cap = ((unsigned int)(rhs.len / KCC_CAPACITY_UNIT) + 1) * KCC_CAPACITY_UNIT;
-        char *buf = (char *)calloc(cap, sizeof(char));
-        strcpy(buf, rhs.cstr);
-        return (string_t) {
-            .len = rhs.len,
-            .cap = cap,
-            .cstr = buf,
-        };
-    }
-    return (string_t) {
-        .len = 0,
-        .cap = 0,
-        .cstr = NULL,
-    };
+    // resizes a capacity.
+    return string_init(rhs.cstr);
 }
 
 void string_append(string_t* lhs, const string_t rhs)

--- a/samples/string.c
+++ b/samples/string.c
@@ -1,0 +1,28 @@
+#include <stdio.h>
+#include <kcc/ext.h>
+
+int main(void)
+{
+    int count = 3;
+    string_t s = string_init("abc");
+    string_t t = string_init("-0123-");
+    for (int i = 0; i < 1000; ++i) {
+        string_append_cstr(&s, "xyz");
+        count += 3;
+        if (i % 2) {
+            string_append(&s, t);
+            count += 6;
+        }
+    }
+    printf("str = %s\n", s.cstr);
+    printf("len = %d\n", s.len);
+    printf("count = %d\n", count);
+
+    string_clear(&s);
+    printf("str = '%s'\n", s.cstr);
+    printf("len = %d\n", s.len);
+
+    string_free(&s);
+
+    return 0;
+}

--- a/src/backend/compile.c
+++ b/src/backend/compile.c
@@ -846,10 +846,10 @@ static enum reg load_float_as_integer(
         next = create_label(definition);
         load_sse(val, xmm0, width);
         if (is_float(val.type)) {
-            limit.f = (float) LONG_MAX;
+            limit.f = (float) LONGLONG_MAX;
             load_sse(var_numeric(basic_type__float, limit), xmm1, width);
         } else {
-            limit.d = (double) LONG_MAX;
+            limit.d = (double) LONGLONG_MAX;
             load_sse(var_numeric(basic_type__double, limit), xmm1, width);
         }
         if (is_float(val.type)) {
@@ -869,7 +869,7 @@ static enum reg load_float_as_integer(
             emit(INSTR_SUBSD, OPT_REG_REG, reg(xmm1, 8), reg(xmm0, 8));
         }
         emit(opcode, OPT_REG_REG, reg(xmm0, width), reg(ax, 8));
-        emit(INSTR_MOV, OPT_IMM_REG, constant(LONG_MAX + 1ul, 8), reg(cx, 8));
+        emit(INSTR_MOV, OPT_IMM_REG, constant(LONGLONG_MAX + 1ul, 8), reg(cx, 8));
         emit(INSTR_XOR, OPT_REG_REG, reg(cx, 8), reg(ax, 8));
         enter_context(next);
     }

--- a/src/backend/vm/vmimplir.c
+++ b/src/backend/vm/vmimplir.c
@@ -298,6 +298,24 @@ static void vm_load_module(struct vm_context *ctx, struct vm_program *prog, stru
                 code = (struct vm_code){ .opcode = opcode, .type = type, .d.imm.ld = ld, };
                 break;
             }
+            case VMOP_FUNCADDR: {
+                struct vm_address addr = vm_load_address(fp, global_base);
+                PUSH_CODE(((struct vm_code){
+                    .opcode = opcode,
+                    .type = type,
+                    .d.addr = addr,
+                }));
+                break;
+            }
+            case VMOP_BUILTIN: {
+                struct vm_address addr = vm_load_address(fp, global_base);
+                PUSH_CODE(((struct vm_code){
+                    .opcode = opcode,
+                    .type = type,
+                    .d.addr = addr,
+                }));
+                break;
+            }
             case VMOP_INT8:     code = (struct vm_code){ .opcode = opcode, .type = type, .d.imm.byte  = vm_load_byte(fp),  }; break;
             case VMOP_INT16:    code = (struct vm_code){ .opcode = opcode, .type = type, .d.imm.word  = vm_load_word(fp),  }; break;
             case VMOP_INT32:    code = (struct vm_code){ .opcode = opcode, .type = type, .d.imm.dword = vm_load_dword(fp), }; break;

--- a/src/backend/vm/vmsevelir.c
+++ b/src/backend/vm/vmsevelir.c
@@ -211,6 +211,8 @@ static void serialize_lir(FILE *fp, struct vm_program *prog)
             case VMOP_UINT16:   sel_put_code_word(fp, code->d.imm.word);   break;
             case VMOP_UINT32:   sel_put_code_dword(fp, code->d.imm.dword); break;
             case VMOP_UINT64:   sel_put_code_qword(fp, code->d.imm.qword); break;
+            case VMOP_FUNCADDR: sel_put_address(fp, code->d.addr);         break;
+            case VMOP_BUILTIN:  sel_put_address(fp, code->d.addr);         break;
             default:
                 printf("type = %d\n", code->type);
                 assert(0);

--- a/src/backend/x86_64/jit.c
+++ b/src/backend/x86_64/jit.c
@@ -892,6 +892,7 @@ INTERNAL int jit_print(void)
 
 INTERNAL int jit_finalize(void)
 {
+    elf_finalize();
     jit_destroy(jit.buffer, jit.size);
     array_clear(&jit.labels);
     array_clear(&jit.jcode);

--- a/src/kcc.c
+++ b/src/kcc.c
@@ -1,4 +1,3 @@
-#include <kcc.h>
 
 extern int kccmain(int argc, char *argv[]);
 

--- a/src/kcc.c
+++ b/src/kcc.c
@@ -1,3 +1,4 @@
+#include <kcc.h>
 
 extern int kccmain(int argc, char *argv[]);
 

--- a/src/kccmain.c
+++ b/src/kccmain.c
@@ -649,6 +649,15 @@ DLLEXPORT int kccmain(int argc, char *argv[])
     int i, ret;
     struct input_file file;
 
+    #if defined(KCC_WINDOWS_DEBUG)
+    _CrtSetReportMode(_CRT_WARN, _CRTDBG_MODE_FILE);
+    _CrtSetReportFile(_CRT_WARN, _CRTDBG_FILE_STDOUT);
+    _CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_FILE);
+    _CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDOUT);
+    _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE);
+    _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDOUT);
+    #endif
+
     setup_args(argc, argv);
     if ((ret = parse_program_arguments(argc, argv)) == 1) {
         goto end;
@@ -679,5 +688,9 @@ end:
     clear_linker_args();
     clear_args(kcc_argc);
     clear_string_all();
+
+    #if defined(KCC_WINDOWS_DEBUG)
+    _CrtDumpMemoryLeaks();
+    #endif
     return ret;
 }

--- a/src/parser/symtab.c
+++ b/src/parser/symtab.c
@@ -535,6 +535,7 @@ INTERNAL struct symbol *sym_create_unnamed(Type type)
     sym->name = str_init(PREFIX_UNNAMED);
     sym->type = type;
     sym->n = ++n;
+    array_push_back(&ns_ident.symbol, sym);
     return sym;
 }
 

--- a/src/parser/typetree.c
+++ b/src/parser/typetree.c
@@ -238,7 +238,7 @@ static struct member *add_member(Type parent, struct member m)
             }
             t->is_flexible = 1;
         }
-        if (LONG_MAX - m.offset < size_of(m.type)) {
+        if (LONGLONG_MAX - m.offset < size_of(m.type)) {
             error("Object is too large.");
             exit(1);
         }
@@ -384,7 +384,7 @@ INTERNAL Type type_create_array(Type next, size_t count)
     Type type;
     struct typetree *t;
 
-    if (count * size_of(next) > LONG_MAX) {
+    if (count * size_of(next) > LONGLONG_MAX) {
         error("Array is too large (%lu elements).", count);
         exit(1);
     }

--- a/src/preprocessor/tokenize.c
+++ b/src/preprocessor/tokenize.c
@@ -186,7 +186,7 @@ static const Type constant_integer_type(
             type = basic_type__int;
         } else if (!is_decimal && value <= UINT_MAX) {
             type = basic_type__unsigned_int;
-        } else if (value <= LONG_MAX) {
+        } else if (value <= LONGLONG_MAX) {
             type = basic_type__long;
         } else {
             type = basic_type__unsigned_long;
@@ -204,7 +204,7 @@ static const Type constant_integer_type(
         break;
     case SUFFIX_L:
     case SUFFIX_LL:
-        if (value <= LONG_MAX) {
+        if (value <= LONGLONG_MAX) {
             type = basic_type__long;
         } else {
             type = basic_type__unsigned_long;


### PR DESCRIPTION
Updated below.

* Windows's LONG is different from Linux's one. It should be LONGLONG on WIndows.
* Added a string sample.
* There is a memory leak. Fixed it and no leak is reported now.
* atexit's buffer is allocated dynamically.
